### PR TITLE
Move reduce responsibility out of scuttle-tag

### DIFF
--- a/pull.js
+++ b/pull.js
@@ -1,50 +1,11 @@
 const pull = require('pull-stream')
-const get = require('lodash/get')
-const set = require('lodash/set')
-const size = require('lodash/size')
-const reduce = require('lodash/reduce')
 const merge = require('lodash/merge')
 const isTag = require('./sync/isTag')
-
-const mapQuery = {
-  $map: {
-    author: ['value', 'author'],
-    tag: ['value', 'content', 'root'],
-    message: ['value', 'content', 'message'],
-    tagged: ['value', 'content', 'tagged'],
-    timestamp: ['value', 'timestamp'],
-    value: 'value'
-  }
-}
-
-const reduceQuery = {
-  $reduce: {
-    message: 'message',
-    tag: {$collect: true}
-  }
-}
 
 const filter = (stream) => {
   return pull(
     stream,
-    pull.filter((message) => {
-      const tagDict = reduce(message.tag, (result, tagMsg) => {
-        if (!isTag(tagMsg.value)) return result
-        const authorTag = get(result, [tagMsg.author, tagMsg.tag])
-        if (!authorTag || tagMsg.timestamp > authorTag.timestamp) {
-          if (tagMsg.tagged) {
-            set(result, [tagMsg.author, tagMsg.tag], tagMsg.value)
-            return result
-          }
-          if (!result[tagMsg.author]) return result
-          delete result[tagMsg.author][tagMsg.tag]
-          return result
-        }
-      }, {})
-      const count = reduce(tagDict, (result, authorTags) => result + size(authorTags), 0)
-      return count > 0
-    }),
-    pull.map((message) => message.message)
+    pull.filter(isTag)
   )
 }
 
@@ -61,9 +22,7 @@ function messagesTagged (server) {
             message: { $prefix: '%' }
           }
         }
-      }},
-      mapQuery,
-      reduceQuery
+      }}
     ]
   })))
 }
@@ -81,9 +40,7 @@ function messagesTaggedWith (server) {
             message: { $prefix: '%' }
           }
         }
-      }},
-      mapQuery,
-      reduceQuery
+      }}
     ]
   })))
 }
@@ -102,9 +59,7 @@ function messagesTaggedBy (server) {
             message: { $prefix: '%' }
           }
         }
-      }},
-      mapQuery,
-      reduceQuery
+      }}
     ]
   })))
 }
@@ -123,9 +78,7 @@ function messagesTaggedWithBy (server) {
             message: { $prefix: '%' }
           }
         }
-      }},
-      mapQuery,
-      reduceQuery
+      }}
     ]
   })))
 }


### PR DESCRIPTION
MFR cannot handle maintaining sort order while reducing. Moving responsibility of reducing tags into message streams to the client. This also gives more flexibility when reducing allowing you to remove messages which were subsequently untagged while reducing.